### PR TITLE
Petites corrections sur les actions batch

### DIFF
--- a/Action/BulkAction.php
+++ b/Action/BulkAction.php
@@ -48,7 +48,7 @@ final class BulkAction extends AbstractAction
 
     }
 
-    public function getAllItems($configurateur, $request){
+    public function getAllItems($configurator, $request){
         $response = $this->comunicateComponents($configurator, $request);
         if($response){
             return $response;

--- a/Resources/views/Component/ListItemsComponent/_bulks.html.twig
+++ b/Resources/views/Component/ListItemsComponent/_bulks.html.twig
@@ -25,7 +25,7 @@
             </div>
             <div class="hidden {{ component.gid('js-all-selection-active') }}">
                 <span class="{{ component.gid('js-all-selection') }}"><i class="fa fa-circle-o"></i>&nbsp;{{ 'lego.bulk.this_page_only'|trans }}</span><br>
-                <span><i class="fa fa-dot-circle-o"></i>&nbsp;{{ 'lego.bulk.this_page_only'|trans }}</span>
+                <span><i class="fa fa-dot-circle-o"></i>&nbsp;{{ 'lego.bulk.all_page'|trans }}</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
* action batch : "Sur toutes les pages" est remplacé par "Uniquement sur la page courante" quand on le sélectionne => corrigé
* action batch : argument avec le mauvais nom dans une fonction